### PR TITLE
Bumps version to 1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "raw-transaction-decoder",
-  "version": "1.0.0",
+  "name": "@synonymdev/raw-transaction-decoder",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "raw-transaction-decoder",
-      "version": "1.0.0",
+      "name": "@synonymdev/raw-transaction-decoder",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "bitcoinjs-lib": "6.1.4"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@synonymdev/raw-transaction-decoder",
   "author": "synonymdev",
   "license": "MIT",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Decodes Raw Bitcoin Transactions",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
This PR:
- Bumps version to `1.1.0` in `package.json`.
- Updates `package-lock.json` accordingly.